### PR TITLE
Add missing dependencies (from bot.py)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,3 +30,6 @@ typing-inspect==0.9.0
 typing_extensions==4.12.2
 tzdata==2024.1
 urllib3==2.2.3
+discord.py==2.4.0
+asyncpg==0.29.0
+asyncssh==2.17.0


### PR DESCRIPTION
`bot.py` requires packages which are not listed in `requirements.txt`. This change adds those dependencies.