### PR TITLE
ignore pycache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .aider*
+__pycache__/


### PR DESCRIPTION
seeing as pycache is all auto-generated binaries, it makes sense to me